### PR TITLE
Create devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "17",
+      "installGradle": true
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,5 +5,11 @@
       "version": "17",
       "installGradle": true
     }
+  },
+  "postCreateCommand": "cd /opt && wget 'https://github.com/wpilibsuite/vscode-wpilib/releases/download/v2024.2.1/vscode-wpilib-2024.2.1.vsix'",
+  "customizations": {
+    "vscode": {
+      "extensions": ["/opt/vscode-wpilib-2024.2.1.vsix","vscjava.vscode-java-pack","vscjava.vscode-gradle"]
+    }
   }
 }


### PR DESCRIPTION
This allows us to use the browser version of vscode, complete with the WPILib plugin. Obviously I don't think we can deploy to the robot, but if we had the robot we'd have the laptops anyway. This might be a way for students who have limited access to programming laptops to be able to work on the code while away from B80. 

We might need to figure out how to get set up with a GitHub non profit plan to have more hours allowed