### PR TITLE
Decouple setting elevator and wrist goal from moving to position

### DIFF
--- a/src/main/java/frc/robot/competition/CompetitionRobotContainer.java
+++ b/src/main/java/frc/robot/competition/CompetitionRobotContainer.java
@@ -290,6 +290,9 @@ class CompetitionRobotContainer {
 
     m_manipController.rightTrigger(0.5).whileTrue(m_feeder.setFeed(RobotConstants.FEED_FIRE_SPEED));
 
+    m_manipController.povDown().onTrue(m_Wrist.decrementAngle());
+    m_manipController.povUp().onTrue(m_Wrist.incrementAngle());
+
     // The routine automatically stops the motors at the end of the command
     sysIdController
         .a()

--- a/src/main/java/frc/robot/competition/CompetitionRobotContainer.java
+++ b/src/main/java/frc/robot/competition/CompetitionRobotContainer.java
@@ -145,13 +145,16 @@ class CompetitionRobotContainer {
         "ScoreFromW2",
         m_Shooter
             .setShooter(RobotConstants.AUTO_SHOOT_SPEED)
-            .alongWith(m_Wrist.setToTarget(RobotConstants.WRIST_W2_TARGET))
+            .alongWith(m_Wrist.setGoal(RobotConstants.WRIST_W2_TARGET))
             .andThen(Commands.waitUntil(m_Wrist::isAtTarget).withTimeout(1)));
     NamedCommands.registerCommand(
         "StartShooter", m_Shooter.setShooter(RobotConstants.AUTO_SHOOT_SPEED));
     NamedCommands.registerCommand(
         "Score",
-        m_feeder.setFeed(RobotConstants.FEED_FIRE_SPEED).until(() -> !m_feeder.isNoteQueued()));
+        m_feeder
+            .setFeed(RobotConstants.FEED_FIRE_SPEED)
+            .until(() -> !m_feeder.isNoteQueued())
+            .andThen(m_Wrist.stow()));
     NamedCommands.registerCommand("StopShooter", m_Shooter.setShooter(0));
     // Need  to add and then to stop the feed and shooter
 
@@ -269,14 +272,17 @@ class CompetitionRobotContainer {
     // Sets elevator and wrist to Amp score position
     m_manipController
         .y()
-        .whileTrue(m_Wrist.setToTarget(19).alongWith(m_Elevator.setToTarget(13.9)))
-        .onFalse(m_Wrist.stow());
+        .onTrue(m_Wrist.setGoal(19).alongWith(m_Elevator.setGoal(13.9)))
+        .onFalse(m_Wrist.stow().alongWith(m_Elevator.stow()));
 
-    m_manipController.a().whileTrue(m_Elevator.setToTarget(RobotConstants.ELEVATOR_CLIMB_HEIGHT));
+    m_manipController
+        .a()
+        .onTrue(m_Elevator.setGoal(RobotConstants.ELEVATOR_CLIMB_HEIGHT))
+        .onFalse(m_Elevator.stow());
 
-    m_manipController.b().whileTrue(m_Elevator.setToTarget(2));
+    m_manipController.b().onTrue(m_Elevator.setGoal(2)).onFalse(m_Elevator.stow());
 
-    m_manipController.x().whileTrue(m_Wrist.setToTarget(38)).onFalse(m_Wrist.stow());
+    m_manipController.x().onTrue(m_Wrist.setGoal(38)).onFalse(m_Wrist.stow());
 
     m_manipController.rightBumper().whileTrue(pickUpNote);
 

--- a/src/main/java/frc/robot/competition/CompetitionRobotContainer.java
+++ b/src/main/java/frc/robot/competition/CompetitionRobotContainer.java
@@ -285,10 +285,39 @@ class CompetitionRobotContainer {
     m_manipController.rightTrigger(0.5).whileTrue(m_feeder.setFeed(RobotConstants.FEED_FIRE_SPEED));
 
     // The routine automatically stops the motors at the end of the command
-    sysIdController.a().whileTrue(m_chassis.sysIdQuasistatic(Direction.kForward));
-    sysIdController.b().whileTrue(m_chassis.sysIdDynamic(Direction.kForward));
-    sysIdController.x().whileTrue(m_chassis.sysIdQuasistatic(Direction.kReverse));
-    sysIdController.y().whileTrue(m_chassis.sysIdDynamic(Direction.kReverse));
+    sysIdController
+        .a()
+        .and(sysIdController.leftBumper())
+        .whileTrue(m_Wrist.sysIdQuasistatic(Direction.kForward));
+    sysIdController
+        .b()
+        .and(sysIdController.leftBumper())
+        .whileTrue(m_Wrist.sysIdQuasistatic(Direction.kReverse));
+    sysIdController
+        .x()
+        .and(sysIdController.leftBumper())
+        .whileTrue(m_Wrist.sysIdDynamic(Direction.kForward));
+    sysIdController
+        .y()
+        .and(sysIdController.leftBumper())
+        .whileTrue(m_Wrist.sysIdDynamic(Direction.kReverse));
+
+    sysIdController
+        .a()
+        .and(sysIdController.rightBumper())
+        .whileTrue(m_Elevator.sysIdQuasistatic(Direction.kForward));
+    sysIdController
+        .b()
+        .and(sysIdController.rightBumper())
+        .whileTrue(m_Elevator.sysIdQuasistatic(Direction.kReverse));
+    sysIdController
+        .x()
+        .and(sysIdController.rightBumper())
+        .whileTrue(m_Elevator.sysIdDynamic(Direction.kForward));
+    sysIdController
+        .y()
+        .and(sysIdController.rightBumper())
+        .whileTrue(m_Elevator.sysIdDynamic(Direction.kReverse));
   }
 
   public Command getAutonomousCommand() {

--- a/src/main/java/frc/robot/competition/Robot.java
+++ b/src/main/java/frc/robot/competition/Robot.java
@@ -19,6 +19,7 @@ import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGReader;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
+import org.littletonrobotics.urcl.URCL;
 import org.opencv.core.Mat;
 import org.opencv.imgproc.Imgproc;
 
@@ -115,6 +116,7 @@ public class Robot extends LoggedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
+    URCL.start();
   }
 
   @Override

--- a/src/main/java/frc/robot/competition/RobotConstants.java
+++ b/src/main/java/frc/robot/competition/RobotConstants.java
@@ -159,7 +159,7 @@ class RobotConstants {
   // Wrist Constants
   public static final int WRIST_ID = 13;
 
-  public static final float WRIST_HIGH_LIM = 50;
+  public static final float WRIST_HIGH_LIM = 55;
   public static final float WRIST_LOW_LIM = 0;
 
   // CANDLE //

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -24,6 +24,7 @@ import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Voltage;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.classes.Util;
@@ -159,11 +160,7 @@ public class Elevator extends SubsystemBase {
    * @param goal Goal height for the elevator in inches.
    */
   public Command setGoal(double goal) {
-    return runOnce(() -> profiledPid.setGoal(Units.inchesToMeters(goal)));
-  }
-
-  public void holdPosition() {
-    profiledPid.setGoal(encoder.getPosition());
+    return Commands.runOnce(() -> profiledPid.setGoal(Units.inchesToMeters(goal)));
   }
 
   public Command stow() {

--- a/src/main/java/frc/robot/subsystems/Wrist.java
+++ b/src/main/java/frc/robot/subsystems/Wrist.java
@@ -5,16 +5,18 @@
 package frc.robot.subsystems;
 
 import static com.revrobotics.CANSparkBase.*;
+import static com.revrobotics.CANSparkBase.ControlType.*;
 import static edu.wpi.first.units.Units.Second;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
 import com.revrobotics.AbsoluteEncoder;
-import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.SparkAbsoluteEncoder.Type;
+import com.revrobotics.SparkPIDController;
+import edu.wpi.first.math.controller.ArmFeedforward;
 import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Voltage;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -27,8 +29,6 @@ public class Wrist extends SubsystemBase {
 
   private CANSparkMax wristNeo;
   private AbsoluteEncoder encoder;
-  private double stowPos = 50;
-  private double target = 0;
 
   private final SysIdRoutine sysIdRoutine =
       new SysIdRoutine(
@@ -43,8 +43,25 @@ public class Wrist extends SubsystemBase {
               this,
               "wrist"));
 
+  private double STOW_ANGLE;
+
+  /** The goal position of the wrist, in degrees */
+  private double goal = STOW_ANGLE;
+
+  private SparkPIDController controller;
+
+  // TODO tune the wrist
+  private ArmFeedforward feedforward = new ArmFeedforward(0, 0, 0, 0);
+
+  /**
+   * The center of mass for the wrist does not perfectly line up with 0º. We need to add this offset
+   * so that the current encoder position lines up with the phase of gravity
+   */
+  private double kGPhaseOffset = 0;
+
   /** Creates a new Wrist. */
   public Wrist(int WRIST_ID, float WRIST_HIGH_LIM, float WRIST_LOW_LIM) {
+    this.STOW_ANGLE = WRIST_HIGH_LIM;
     wristNeo = new CANSparkMax(WRIST_ID, MotorType.kBrushless);
 
     wristNeo.restoreFactoryDefaults();
@@ -54,8 +71,8 @@ public class Wrist extends SubsystemBase {
     encoder = wristNeo.getAbsoluteEncoder(Type.kDutyCycle);
     encoder.setPositionConversionFactor(360);
     encoder.setVelocityConversionFactor(360.0 / 60.0);
-    wristNeo.getPIDController().setFeedbackDevice(encoder);
-    wristNeo.getPIDController().setP(.03);
+    this.controller = wristNeo.getPIDController();
+    controller.setP(.03);
 
     encoder.setInverted(true);
     encoder.setZeroOffset(0);
@@ -67,19 +84,12 @@ public class Wrist extends SubsystemBase {
     wristNeo.enableSoftLimit(SoftLimitDirection.kReverse, true);
 
     Util.setRevStatusRates(wristNeo, 10, 20, 65535, 65535, 65535, 20, 65535, 65535);
-  }
 
-  public Command setToTarget(double target) {
-    this.target = target;
-    return runOnce(() -> wristNeo.getPIDController().setReference(target, ControlType.kPosition));
-  }
-
-  public Command stow() {
-    return setToTarget(stowPos);
+    setDefaultCommand(run(this::moveWrist));
   }
 
   public boolean isAtTarget() {
-    return Math.abs(target - encoder.getPosition()) < 2;
+    return Math.abs(goal - encoder.getPosition()) < 2;
   }
 
   private void configureMotorsBeforeSysId() {
@@ -99,7 +109,40 @@ public class Wrist extends SubsystemBase {
   public Command sysIdDynamic(SysIdRoutine.Direction direction) {
     return runOnce(this::configureMotorsBeforeSysId)
         .andThen(sysIdRoutine.dynamic(direction))
-        .finallyDo(this::configureMotorsAfterSysId);
+        .finallyDo(
+            () -> {
+              configureMotorsAfterSysId();
+              holdPosition();
+            });
+  }
+
+  /**
+   * Moves the wrist to a position when the command is scheduled, and resets to stow when the
+   * command ends.
+   *
+   * <p>This will work with both whileTrue and toggleOnTrue for joystick bindings
+   *
+   * @param goal Goal angle for the wrist in degrees.
+   */
+  public Command setGoal(double goal) {
+    return runOnce(() -> this.goal = goal);
+  }
+
+  private void holdPosition() {
+    this.goal = encoder.getPosition();
+  }
+
+  public Command stow() {
+    return setGoal(STOW_ANGLE);
+  }
+
+  /**
+   * This method actually moves the wrist. The default command will move the wrist to the current
+   * goal
+   */
+  private void moveWrist() {
+    double ff = feedforward.calculate(encoder.getPosition() + kGPhaseOffset, 0);
+    controller.setReference(goal, kPosition, 0, ff);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Wrist.java
+++ b/src/main/java/frc/robot/subsystems/Wrist.java
@@ -19,6 +19,7 @@ import com.revrobotics.SparkPIDController;
 import edu.wpi.first.math.controller.ArmFeedforward;
 import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Voltage;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
@@ -88,6 +89,14 @@ public class Wrist extends SubsystemBase {
     setDefaultCommand(run(this::moveWrist));
   }
 
+  public Command incrementAngle() {
+    return runOnce(() -> goal += 1);
+  }
+
+  public Command decrementAngle() {
+    return runOnce(() -> goal -= 1);
+  }
+
   public boolean isAtTarget() {
     return Math.abs(goal - encoder.getPosition()) < 2;
   }
@@ -149,5 +158,6 @@ public class Wrist extends SubsystemBase {
   public void periodic() {
     // This method will be called once per scheduler run
     Logger.recordOutput("Wrist Enc Pos", encoder.getPosition());
+    SmartDashboard.putNumber("wrist/goal", goal);
   }
 }

--- a/src/main/java/frc/robot/subsystems/Wrist.java
+++ b/src/main/java/frc/robot/subsystems/Wrist.java
@@ -21,6 +21,7 @@ import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Voltage;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.classes.Util;
@@ -90,11 +91,11 @@ public class Wrist extends SubsystemBase {
   }
 
   public Command incrementAngle() {
-    return runOnce(() -> goal += 1);
+    return Commands.runOnce(() -> goal += 1);
   }
 
   public Command decrementAngle() {
-    return runOnce(() -> goal -= 1);
+    return Commands.runOnce(() -> goal -= 1);
   }
 
   public boolean isAtTarget() {
@@ -132,11 +133,11 @@ public class Wrist extends SubsystemBase {
    * @param goal Goal angle for the wrist in degrees.
    */
   public Command setGoal(double goal) {
-    return runOnce(() -> this.goal = goal);
+    return Commands.runOnce(() -> this.goal = goal);
   }
 
   private Command holdPosition() {
-    return runOnce(() -> this.goal = encoder.getPosition());
+    return Commands.runOnce(() -> this.goal = encoder.getPosition());
   }
 
   public Command stow() {

--- a/src/main/java/frc/robot/subsystems/Wrist.java
+++ b/src/main/java/frc/robot/subsystems/Wrist.java
@@ -112,17 +112,15 @@ public class Wrist extends SubsystemBase {
   public Command sysIdQuasistatic(SysIdRoutine.Direction direction) {
     return runOnce(this::configureMotorsBeforeSysId)
         .andThen(sysIdRoutine.quasistatic(direction))
-        .finallyDo(this::configureMotorsAfterSysId);
+        .andThen(holdPosition())
+        .andThen(this::configureMotorsAfterSysId);
   }
 
   public Command sysIdDynamic(SysIdRoutine.Direction direction) {
     return runOnce(this::configureMotorsBeforeSysId)
         .andThen(sysIdRoutine.dynamic(direction))
-        .finallyDo(
-            () -> {
-              configureMotorsAfterSysId();
-              holdPosition();
-            });
+        .andThen(holdPosition())
+        .andThen(this::configureMotorsAfterSysId);
   }
 
   /**
@@ -137,8 +135,8 @@ public class Wrist extends SubsystemBase {
     return runOnce(() -> this.goal = goal);
   }
 
-  private void holdPosition() {
-    this.goal = encoder.getPosition();
+  private Command holdPosition() {
+    return runOnce(() -> this.goal = encoder.getPosition());
   }
 
   public Command stow() {

--- a/src/main/java/frc/robot/subsystems/chassis/Chassis.java
+++ b/src/main/java/frc/robot/subsystems/chassis/Chassis.java
@@ -13,7 +13,6 @@ import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Voltage;
-import edu.wpi.first.wpilibj.sysid.SysIdRoutineLog;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
@@ -94,14 +93,7 @@ public class Chassis extends SubsystemBase {
   private SysIdRoutine drivetrainRoutine =
       new SysIdRoutine(
           new SysIdRoutine.Config(null, null, Seconds.of(3)),
-          new SysIdRoutine.Mechanism(this::voltageDrive, this::logMotor, this));
-
-  public void logMotor(SysIdRoutineLog log) {
-    for (SwerveModule module : modules) {
-      // Each motor will write to the log directly
-      module.logMotor(log);
-    }
-  }
+          new SysIdRoutine.Mechanism(this::voltageDrive, null, this, "chassis"));
 
   public Command sysIdQuasistatic(SysIdRoutine.Direction direction) {
     return drivetrainRoutine.quasistatic(direction);

--- a/src/main/java/frc/robot/subsystems/chassis/NeoModule.java
+++ b/src/main/java/frc/robot/subsystems/chassis/NeoModule.java
@@ -4,10 +4,6 @@
 
 package frc.robot.subsystems.chassis;
 
-import static edu.wpi.first.units.Units.Meters;
-import static edu.wpi.first.units.Units.MetersPerSecond;
-import static edu.wpi.first.units.Units.Volts;
-
 import com.revrobotics.AbsoluteEncoder;
 import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkLowLevel.MotorType;
@@ -20,11 +16,6 @@ import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
-import edu.wpi.first.units.Distance;
-import edu.wpi.first.units.MutableMeasure;
-import edu.wpi.first.units.Velocity;
-import edu.wpi.first.units.Voltage;
-import edu.wpi.first.wpilibj.sysid.SysIdRoutineLog;
 import frc.robot.classes.ModuleConfig;
 import frc.robot.classes.Structs.FFConstants;
 import frc.robot.classes.Util;
@@ -268,27 +259,5 @@ public class NeoModule implements SwerveModule {
   public void openLoopDiffDrive(double voltage) {
     steerPID.setReference(0, ControlType.kPosition);
     drive.setVoltage(voltage);
-  }
-
-  /*
-   * Mutate these each time we log so that we aren't creating objects constantly
-   */
-  private final MutableMeasure<Voltage> mutableAppliedVoltage = MutableMeasure.mutable(Volts.of(0));
-  private final MutableMeasure<Distance> mutableDistance = MutableMeasure.mutable(Meters.of(0));
-  private final MutableMeasure<Velocity<Distance>> mutableVelocity =
-      MutableMeasure.mutable(MetersPerSecond.of(0));
-
-  public void logMotor(SysIdRoutineLog log) {
-    log.motor("motor#" + driveID)
-        // Log voltage
-        .voltage(
-            /* getAppliedOutput returns the duty cycle which is from [-1, +1].
-            We multiply this by the voltage going into the spark max,
-            called the bus voltage to receive the output voltage */
-            mutableAppliedVoltage.mut_replace(
-                drive.getAppliedOutput() * drive.getBusVoltage(), Volts))
-        // the drive encoder has the necessary position and velocity conversion factors already set
-        .linearVelocity(mutableVelocity.mut_replace(driveEnc.getVelocity(), MetersPerSecond))
-        .linearPosition(mutableDistance.mut_replace(driveEnc.getPosition(), Meters));
   }
 }

--- a/src/main/java/frc/robot/subsystems/chassis/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/chassis/SwerveModule.java
@@ -7,7 +7,6 @@ package frc.robot.subsystems.chassis;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
-import edu.wpi.first.wpilibj.sysid.SysIdRoutineLog;
 
 /**
  * This is the parent interface for a SwerveModule. It is used to define the methods that all
@@ -42,7 +41,4 @@ public interface SwerveModule {
 
   /** Runs the drive motor at a set voltage, while keeping the steer angle at 0 degrees */
   void openLoopDiffDrive(double voltage);
-
-  /** Logs the motor position, velocity, and voltage data for SysId */
-  void logMotor(SysIdRoutineLog log);
 }

--- a/vendordeps/URCL.json
+++ b/vendordeps/URCL.json
@@ -1,0 +1,65 @@
+{
+    "fileName": "URCL.json",
+    "name": "URCL",
+    "version": "2024.0.1",
+    "frcYear": "2024",
+    "uuid": "84246d17-a797-4d1e-bd9f-c59cd8d2477c",
+    "mavenUrls": [
+        "https://raw.githubusercontent.com/Mechanical-Advantage/URCL/2024.0.1"
+    ],
+    "jsonUrl": "https://raw.githubusercontent.com/Mechanical-Advantage/URCL/maven/URCL.json",
+    "javaDependencies": [
+        {
+            "groupId": "org.littletonrobotics.urcl",
+            "artifactId": "URCL-java",
+            "version": "2024.0.1"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "org.littletonrobotics.urcl",
+            "artifactId": "URCL-driver",
+            "version": "2024.0.1",
+            "skipInvalidPlatforms": true,
+            "isJar": false,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "org.littletonrobotics.urcl",
+            "artifactId": "URCL-cpp",
+            "version": "2024.0.1",
+            "libName": "URCL",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "org.littletonrobotics.urcl",
+            "artifactId": "URCL-driver",
+            "version": "2024.0.1",
+            "libName": "URCLDriver",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena",
+                "osxuniversal"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This change allows the default command to be move the wrist / elevator to the set target, rather than a predefined one.
The reason this is necessary is so that we can add in manual control, and when the manual control is done, hold the elevator
at whatever position it is at, rather than resetting back down to 0.

Now commands will set the target position, which is a `runOnce` so it doesn't block the defaultc command from running. To get the
wrist / elevator to move back to the stow position, we need to call `.stow()` in `onFalse`.

Manual controls can be added that simply increase / decrease the goal by some delta, and then this goal will be persisted until an 'automated' command's `onFalse` is triggered again.
