### PR TITLE
Add slow-shot button to SD

### DIFF
--- a/src/main/java/frc/robot/competition/CompetitionRobotContainer.java
+++ b/src/main/java/frc/robot/competition/CompetitionRobotContainer.java
@@ -4,8 +4,6 @@
 
 package frc.robot.competition;
 
-import static frc.robot.subsystems.Shooter.*;
-
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.auto.NamedCommands;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -144,15 +142,15 @@ class CompetitionRobotContainer {
     NamedCommands.registerCommand(
         "ScoreFromW2",
         m_Shooter
-            .setShooter(RobotConstants.AUTO_SHOOT_SPEED)
+            .setSpeed(RobotConstants.AUTO_SHOOT_SPEED)
             .alongWith(m_Wrist.setToTarget(RobotConstants.WRIST_W2_TARGET))
             .andThen(Commands.waitUntil(m_Wrist::isAtTarget).withTimeout(1)));
     NamedCommands.registerCommand(
-        "StartShooter", m_Shooter.setShooter(RobotConstants.AUTO_SHOOT_SPEED));
+        "StartShooter", m_Shooter.setSpeed(RobotConstants.AUTO_SHOOT_SPEED));
     NamedCommands.registerCommand(
         "Score",
         m_feeder.setFeed(RobotConstants.FEED_FIRE_SPEED).until(() -> !m_feeder.isNoteQueued()));
-    NamedCommands.registerCommand("StopShooter", m_Shooter.setShooter(0));
+    NamedCommands.registerCommand("StopShooter", m_Shooter.setSpeed(0));
     // Need  to add and then to stop the feed and shooter
 
     AutoBuilder.configureHolonomic(
@@ -263,8 +261,8 @@ class CompetitionRobotContainer {
 
     m_manipController
         .leftTrigger(0.5)
-        .whileTrue(m_Shooter.setShooter(4250))
-        .whileFalse(m_Shooter.setShooter(0));
+        .onTrue(m_Shooter.setSpeed(4250))
+        .onFalse(m_Shooter.setSpeed(0));
 
     // Sets elevator and wrist to Amp score position
     m_manipController

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -9,6 +9,8 @@ import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.VelocityVoltage;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.pathplanner.lib.util.PIDConstants;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.classes.Structs.FFConstants;
@@ -24,6 +26,10 @@ public class Shooter extends SubsystemBase {
   private final VelocityVoltage shooterBottomVV;
 
   private final ShooterConfig config;
+
+  private final NetworkTableEntry slowShot;
+
+  private final double slowShotSpeed = 500;
 
   /** Creates a new Shooter. */
   public Shooter(ShooterConfig config) {
@@ -62,6 +68,10 @@ public class Shooter extends SubsystemBase {
 
     shooterTOP.optimizeBusUtilization();
     shooterBOTTOM.optimizeBusUtilization();
+
+    slowShot = SmartDashboard.getEntry("shooter/slowShot");
+    slowShot.setPersistent();
+    slowShot.setDefaultBoolean(false);
   }
 
   public boolean isAtSpeed(double threshold) {
@@ -69,23 +79,30 @@ public class Shooter extends SubsystemBase {
         && (shooterTopVV.Velocity != 0));
   }
 
-  public void setPIDReferenceTOP(double setPoint) {
+  private void setPIDReferenceTOP(double setPoint) {
     shooterTOP.setControl(
         shooterTopVV.withVelocity(setPoint / 60).withFeedForward(config.flywheelTopFF.kFF));
   }
 
-  public void setPIDReferenceBOTTOM(double setPoint) {
+  private void setPIDReferenceBOTTOM(double setPoint) {
     shooterBOTTOM.setControl(
         shooterBottomVV.withVelocity(setPoint / 60).withFeedForward(config.flywheelTopFF.kFF));
   }
 
-  public void setPIDReferenceBOTH(double setPoint) {
+  private void setPIDReferenceBOTH(double setPoint) {
     setPIDReferenceTOP(setPoint);
     setPIDReferenceBOTTOM(setPoint);
   }
 
-  public Command setShooter(double setPoint) {
-    return this.runOnce(() -> this.setPIDReferenceBOTH(setPoint));
+  public Command setSpeed(double setPoint) {
+    return this.runOnce(
+        () -> {
+          if (slowShot.getBoolean(false)) {
+            this.setPIDReferenceBOTH(Math.min(setPoint, slowShotSpeed));
+          } else {
+            this.setPIDReferenceBOTH(setPoint);
+          }
+        });
   }
 
   @Override


### PR DESCRIPTION
This adds a persistant button to smart dashboard that keeps the shot speed low.

Useful for testing autos and running robot in the pit
