### PR TITLE
BattleCry Updates

### DIFF
--- a/src/main/java/frc/robot/classes/BaseDrive.java
+++ b/src/main/java/frc/robot/classes/BaseDrive.java
@@ -47,10 +47,9 @@ public class BaseDrive {
     double speed = trigger * motionLimits.maxSpeed;
     double angularSpeed = trigger * motionLimits.maxAngularSpeed;
 
-    double x = xLimiter.calculate(Util.modifyJoystick(xSupplier.getAsDouble()) * speed);
-    double y = yLimiter.calculate(Util.modifyJoystick(ySupplier.getAsDouble()) * speed);
-    double rot =
-        thetaLimiter.calculate(Util.modifyJoystick(rotSupplier.getAsDouble()) * angularSpeed);
+    double x = Util.modifyJoystick(xSupplier.getAsDouble()) * speed;
+    double y = Util.modifyJoystick(ySupplier.getAsDouble()) * speed;
+    double rot = Util.modifyJoystick(rotSupplier.getAsDouble()) * angularSpeed;
 
     return new ChassisSpeeds(x, y, rot);
   }

--- a/src/main/java/frc/robot/competition/CompetitionRobotContainer.java
+++ b/src/main/java/frc/robot/competition/CompetitionRobotContainer.java
@@ -29,7 +29,6 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
-import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
 import frc.robot.classes.BaseDrive;
 import frc.robot.commands.AlignToNote;
 import frc.robot.commands.AlignToPose;
@@ -509,10 +508,7 @@ class CompetitionRobotContainer {
     // sysIdController.b().whileTrue(m_chassis.sysIdDynamic(Direction.kForward));
     // sysIdController.x().whileTrue(m_chassis.sysIdQuasistatic(Direction.kReverse));
     // sysIdController.y().whileTrue(m_chassis.sysIdDynamic(Direction.kReverse));
-    sysIdController.a().whileTrue(m_Shooter.sysIdDynamic(Direction.kForward));
-    sysIdController.b().whileTrue(m_Shooter.sysIdDynamic(Direction.kReverse));
-    sysIdController.x().whileTrue(m_Shooter.sysIdQuasistatic(Direction.kForward));
-    sysIdController.y().whileTrue(m_Shooter.sysIdQuasistatic(Direction.kForward));
+    sysIdController.a().whileTrue(m_Shooter.sysIdRoutine());
 
     RobotModeTriggers.teleop()
         .onTrue(

--- a/src/main/java/frc/robot/competition/RobotConstants.java
+++ b/src/main/java/frc/robot/competition/RobotConstants.java
@@ -165,10 +165,10 @@ class RobotConstants {
           true,
           new Range(-1, 1),
           new Range(-1, 1),
-          new PIDConstants(0, 0, 0),
-          new PIDConstants(0, 0, 0),
-          new FFConstants(0.015904, 0.11136, 0.011126, 0.0),
-          new FFConstants(0.021249, 0.11118, 0.00941906, 0.0));
+          new PIDConstants(.15045, 0, 0),
+          new PIDConstants(0.14965, 0, 0),
+          new FFConstants(0.11599, 0.11275, 0.018537, 0.0),
+          new FFConstants(0.12435, 0.1115, 0.018978, 0.0));
 
   // Wrist Constants
   public static final int WRIST_ID = 13;

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -18,6 +18,7 @@ import com.pathplanner.lib.util.PIDConstants;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.classes.Structs.FFConstants;
@@ -100,12 +101,12 @@ public class Shooter extends SubsystemBase {
   }
 
   private void configureMotorsBeforeSysId() {
-    shooterTOP.getVelocity().setUpdateFrequency(1000);
-    shooterTOP.getMotorVoltage().setUpdateFrequency(1000);
-    shooterTOP.getPosition().setUpdateFrequency(1000);
-    shooterBOTTOM.getVelocity().setUpdateFrequency(1000);
-    shooterBOTTOM.getMotorVoltage().setUpdateFrequency(1000);
-    shooterBOTTOM.getPosition().setUpdateFrequency(1000);
+    shooterTOP.getVelocity().setUpdateFrequency(50);
+    shooterTOP.getMotorVoltage().setUpdateFrequency(50);
+    shooterTOP.getPosition().setUpdateFrequency(50);
+    shooterBOTTOM.getVelocity().setUpdateFrequency(50);
+    shooterBOTTOM.getMotorVoltage().setUpdateFrequency(50);
+    shooterBOTTOM.getPosition().setUpdateFrequency(50);
   }
 
   public void configureMotorsAfterSysId() {
@@ -117,16 +118,18 @@ public class Shooter extends SubsystemBase {
     shooterBOTTOM.getPosition().setUpdateFrequency(0);
   }
 
-  public Command sysIdQuasistatic(SysIdRoutine.Direction direction) {
-    return runOnce(this::configureMotorsBeforeSysId)
-        .andThen(sysIdRoutine.quasistatic(direction))
-        .andThen(runOnce(this::configureMotorsAfterSysId));
-  }
-
-  public Command sysIdDynamic(SysIdRoutine.Direction direction) {
-    return runOnce(this::configureMotorsBeforeSysId)
-        .andThen(sysIdRoutine.dynamic(direction))
-        .andThen(runOnce(this::configureMotorsAfterSysId));
+  public Command sysIdRoutine() {
+    return Commands.sequence(
+        runOnce(this::configureMotorsBeforeSysId),
+        Commands.waitSeconds(1),
+        sysIdRoutine.dynamic(SysIdRoutine.Direction.kForward),
+        Commands.waitSeconds(1),
+        sysIdRoutine.dynamic(SysIdRoutine.Direction.kReverse),
+        Commands.waitSeconds(1),
+        sysIdRoutine.quasistatic(SysIdRoutine.Direction.kForward),
+        Commands.waitSeconds(1),
+        sysIdRoutine.quasistatic(SysIdRoutine.Direction.kReverse),
+        runOnce(this::configureMotorsAfterSysId));
   }
 
   public boolean isAtSpeed(double threshold) {

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -101,19 +101,15 @@ public class Shooter extends SubsystemBase {
   }
 
   private void configureMotorsBeforeSysId() {
-    shooterTOP.getVelocity().setUpdateFrequency(50);
     shooterTOP.getMotorVoltage().setUpdateFrequency(50);
     shooterTOP.getPosition().setUpdateFrequency(50);
-    shooterBOTTOM.getVelocity().setUpdateFrequency(50);
     shooterBOTTOM.getMotorVoltage().setUpdateFrequency(50);
     shooterBOTTOM.getPosition().setUpdateFrequency(50);
   }
 
   public void configureMotorsAfterSysId() {
-    shooterTOP.getVelocity().setUpdateFrequency(50);
     shooterTOP.getMotorVoltage().setUpdateFrequency(0);
     shooterTOP.getPosition().setUpdateFrequency(0);
-    shooterBOTTOM.getVelocity().setUpdateFrequency(50);
     shooterBOTTOM.getMotorVoltage().setUpdateFrequency(0);
     shooterBOTTOM.getPosition().setUpdateFrequency(0);
   }

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -70,6 +70,7 @@ public class Shooter extends SubsystemBase {
     shooterTOP.setInverted(config.flywheelTopInverted);
     shooterTopConfig.kS = config.flywheelTopFF.kS;
     shooterTopConfig.kV = config.flywheelTopFF.kV;
+    shooterTopConfig.kA = config.flywheelTopFF.kA;
     shooterTopConfig.kP = config.flywheelTopPID.kP;
     shooterTopConfig.kI = config.flywheelTopPID.kI;
     shooterTopConfig.kD = config.flywheelTopPID.kD;
@@ -80,6 +81,7 @@ public class Shooter extends SubsystemBase {
     shooterBOTTOM.setInverted(config.flywheelBottomInverted);
     shooterBottomConfig.kS = config.flywheelBottomFF.kS;
     shooterBottomConfig.kV = config.flywheelBottomFF.kV;
+    shooterBottomConfig.kA = config.flywheelBottomFF.kA;
     shooterBottomConfig.kP = config.flywheelBottomPID.kP;
     shooterBottomConfig.kI = config.flywheelBottomPID.kI;
     shooterBottomConfig.kD = config.flywheelBottomPID.kD;
@@ -134,12 +136,18 @@ public class Shooter extends SubsystemBase {
 
   private void setPIDReferenceTOP(double setPoint) {
     shooterTOP.setControl(
-        shooterTopVV.withVelocity(setPoint / 60).withFeedForward(config.flywheelTopFF.kFF));
+        shooterTopVV
+            .withVelocity(setPoint / 60)
+            .withEnableFOC(true)
+            .withFeedForward(config.flywheelTopFF.kFF));
   }
 
   private void setPIDReferenceBOTTOM(double setPoint) {
     shooterBOTTOM.setControl(
-        shooterBottomVV.withVelocity(setPoint / 60).withFeedForward(config.flywheelTopFF.kFF));
+        shooterBottomVV
+            .withVelocity(setPoint / 60)
+            .withEnableFOC(true)
+            .withFeedForward(config.flywheelTopFF.kFF));
   }
 
   private void setPIDReferenceBOTH(double setPoint) {

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -161,7 +161,7 @@ public class Shooter extends SubsystemBase {
                 this.setPIDReferenceBOTH(setPoint);
               }
             })
-        .withName("Set Speed - Shooter");
+        .withName("Set Speed [" + setPoint + "]");
   }
 
   public void setSpeed(double setPoint) {


### PR DESCRIPTION
- **Update shooter characteristics**
- **Add setpoint to command log**
- **Remove limit on drive and enable FOC on shooter**

The removal of the slew rate limiter was due to it affecting deceleration as well as acceleration.
Response from Hailey was that without the slew limiter it was better.
We should keep an eye on current logs and adjust the current limit if needed
